### PR TITLE
Fixing error when calling files method on an empty directory

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -22,14 +22,7 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
 			dirs:[]
 		};
 
-	var done = function(results) {
-		if (!results) {
-			results = type === 'all' ? {
-				files: [],
-				dirs: []
-			} : [];
-		}
-
+	var done = function() {
 		if (ignoreType || type === 'all') {
 			callback(null, results);
 		}


### PR DESCRIPTION
Just moved the done function out of the getStatHandler method so that it can be called when no files/directories are returned when fs.readdir's callback is executed - currently it throws an error
