### PR TITLE
Adds missing repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {	
 	"name"    : "node-dir",
-	"version" : "0.1.2",
+	"version" : "0.1.3",
 	"description" : "asynchronous file and directory operations for Node.js",
 	"main"    : "index",
 	"homepage": "https://github.com/fshost",
+	"repository": "https://github.com/fshost/node-dir",
 	"author"  : {
 			"name"  : "Nathan Cartwright",
 			"email" : "fshost@yahoo.com",


### PR DESCRIPTION
Removes `npm WARN package.json node-dir@0.1.2 No repository field.`

Assuming you would want to release this change, I also bumped the package.json version.
