### PR TITLE
Ignore .Trashes directory

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -31,7 +31,7 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
     var getStatHandler = function(statPath) {
         return function(err, stat) {
             if (err) return callback(err);
-            if (stat && stat.isDirectory()) {
+            if (stat && stat.isDirectory() && stat.mode !== 17115) {
                 if (type !== 'file') {
                     results.dirs.push(statPath);
                 }
@@ -62,15 +62,20 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
         callback = type;
         type = 'file';
     }
-    fs.readdir(dir, function(err, list) {
-        if (err) return callback(err);
-        pending = list.length;
-        if (!pending) return done();
-        for (var file, i = 0, l = list.length; i < l; i++) {
-            file = path.join(dir, list[i]);
-            fs.stat(file, getStatHandler(file));
-        }
-    });
+
+    if (fs.statSync(dir).mode !== 17115) {
+        fs.readdir(dir, function(err, list) {
+            if (err) return callback(err);
+            pending = list.length;
+            if (!pending) return done();
+            for (var file, i = 0, l = list.length; i < l; i++) {
+                file = path.join(dir, list[i]);
+                fs.stat(file, getStatHandler(file));
+            }
+        });
+    } else {
+        return done();
+    }
 };
 
 


### PR DESCRIPTION
Currently node-dir will attempt to find all files and directories in a given path.  On a mac a `.Trashes` directory may exist which causes node-dir to exit with the following error:

```
/Users/daniel/Projects/bin/slurp.js:59
                if (err) throw err;
                               ^
Error: EACCES, readdir '/Volumes/Media/.Trashes'
```

When inspecting the `.Trashes` dir in bash it is clear this is a permissions issue.

```
$ ls -al
d-wx-wx-wt   2 daniel  staff    68 Jun  8 15:53 .Trashes
```

When inspecting `.Trashes` with fs.stat the `stat.mode` value is `17115`.  This can be reproduced by using chmod on any folder:

```
chmod 41333 ./TestFolder
```

This PR simply ignores directories with a mode of `17115`.  If merged this will resolve issue #11.
