### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "engines": {
     "node": ">= 0.10.5"
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "keywords": [
     "node-dir",
     "directory",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/