### PR TITLE
Replace statSync call with an async call

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -63,7 +63,10 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
         type = 'file';
     }
 
-    if (fs.statSync(dir).mode !== 17115) {
+    fs.stat(dir, function(err, stat) {
+        if (err) return callback(err);
+        if(stat && stat.mode === 17115) return done();
+
         fs.readdir(dir, function(err, list) {
             if (err) return callback(err);
             pending = list.length;
@@ -73,9 +76,7 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
                 fs.stat(file, getStatHandler(file));
             }
         });
-    } else {
-        return done();
-    }
+    });
 };
 
 


### PR DESCRIPTION
Since `statSync` throws, I was getting a crash when directories didn't exist.