### PR TITLE
Don't call stream.setEncoding() if options.encoding is strictly null

### DIFF
--- a/lib/readfilesstream.js
+++ b/lib/readfilesstream.js
@@ -108,7 +108,9 @@ function readFilesStream(dir, options, callback, complete) {
                     if (options.shortName) files.push(filename);
                     else files.push(file);
                     var stream = fs.createReadStream(file);
-                    stream.setEncoding(options.encoding);
+                    if (options.encoding !== null) {
+                        stream.setEncoding(options.encoding);
+                    }
                     stream.on('error',function(err) {
                       if (options.doneOnErr === true) return done(err);
                       next();


### PR DESCRIPTION
When stream.setEncoding is called, it additionally sets the decoder in the underlying stream. Unfortunately, despite what [the official documentation](https://nodejs.org/docs/latest-v5.x/api/stream.html#stream_readable_setencoding_encoding) says, calling `setEncoding(null)` sets the underlying decoder to UTF-8.

This causes problems when you need the raw buffer data of a file to pipe elsewhere, such as a zlib.gunzip stream for gunzipping files.

This pull request allows specifying `{ encoding: null }` to disable that call.