### PR TITLE
Security vulnerability - update minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-dir",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "asynchronous file and directory operations for Node.js",
   "main": "index",
   "homepage": "https://github.com/fshost",
@@ -31,7 +31,7 @@
     "fs"
   ],
   "dependencies": {
-    "minimatch": "~2.0.10"
+    "minimatch": "^3.0.2"
   },
   "devDependencies": {
     "mocha": "~1.13.0",


### PR DESCRIPTION
The `minimatch` dependency has a regex DOS vulnerability affecting versions <=3.0.1
https://nodesecurity.io/advisories/118

A lot of NPM modules rely on `node-dir`, so this could potentially be serious for consumers depending on how the calling code is handling file path inputs.

This represents a major version bump from 2 => 3 for `minimatch`, however the `node-dir` tests all passed for me after the update.

I will perform additional validation of this PR as advised.