### PR TITLE
Replaced .stat with .lstat in order to support broken symlinks

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -63,7 +63,7 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
         type = 'file';
     }
 
-    fs.stat(dir, function(err, stat) {
+    fs.lstat(dir, function(err, stat) {
         if (err) return callback(err);
         if(stat && stat.mode === 17115) return done();
 
@@ -73,7 +73,7 @@ exports.files = function files(dir, type, callback, /* used internally */ ignore
             if (!pending) return done();
             for (var file, i = 0, l = list.length; i < l; i++) {
                 file = path.join(dir, list[i]);
-                fs.stat(file, getStatHandler(file));
+                fs.lstat(file, getStatHandler(file));
             }
         });
     });


### PR DESCRIPTION
The current implementation does not work with broken symlinks.
An "ENOENT: no such file or directory" error is returned.
