### PR TITLE
Remove unnecessary special character

### DIFF
--- a/lib/readfiles.js
+++ b/lib/readfiles.js
@@ -62,7 +62,7 @@ function readFiles(dir, options, callback, complete) {
     };
 
     fs.readdir(dir, function(err, list) {
-        if (err)  {
+        if (err) {
             if (options.doneOnErr === true) {
               if (err.code === 'EACCES') return done();
               return done(err);


### PR DESCRIPTION
As I was working on a project, this error was thrown at me:
![image](https://user-images.githubusercontent.com/969493/91958766-10775a00-ed08-11ea-88d9-348b7be3a356.png)
It only occured when I was using the production build, as the Javascript Bundler I used (webpack) came with a dev-server that for some reason did not throw this error.

Upon closer inspecting of the line that this "unexpected"  token is found, I found the sourcecode of this project:
![image](https://user-images.githubusercontent.com/969493/91958920-40266200-ed08-11ea-9e38-1a4b68f70d05.png)

After being extremely confused about this for a few days, I searched through all the code in my dependencies for that dreaded Â character. I did not find it. So I searched for all the various bits of code I saw *around* this broken character, which led me to the function in this Pull Request.
You see when you just use this function in a UTF-8 environment, it all works fine. You wouldn't even notice it. But I forgot the meta "charset" html tag on my project, as this was very early in development and this error had me stumped. This omitted tag made the character set default to ISO-8859-1 (which would've caused other problems too I'm sure) and turns this innocent "no-breaking space" into " Â", breaking any interpreter.

This proposed change removes this character and replaces it with a space, to save someone elses sanity.

**Edit**: Oh, of course. This project is abandoned. Oh well, maybe some unfortunate soul will find this PR and it may help them.