### PR TITLE
Update paths.js

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -89,7 +89,9 @@ exports.files = function files(dir, type, callback, options) {
               results.files = results.files.concat(res.files);
               results.dirs = results.dirs.concat(res.dirs);
             } else if (type === 'file') {
-                results.files = results.files.concat(res.files);
+                if  ( typeof res != 'undefined' )       {
+                    results.files = results.files.concat(res.files);
+                }
             } else {
                 results.dirs = results.dirs.concat(res.dirs);
             }

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -89,7 +89,7 @@ exports.files = function files(dir, type, callback, options) {
               results.files = results.files.concat(res.files);
               results.dirs = results.dirs.concat(res.dirs);
             } else if (type === 'file') {
-                if  ( typeof res != 'undefined' )       {
+                if  ( typeof res != 'undefined' && typeof res.files != 'undefined')       {
                     results.files = results.files.concat(res.files);
                 }
             } else {


### PR DESCRIPTION
if a directory is empty, `paths.js` crashes with "TypeError: Cannot read properties of undefined (reading 'files')" error.